### PR TITLE
Remove final from classes and methods on well known type classes.

### DIFF
--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -2,6 +2,14 @@
 This changelog references the relevant changes done in 1.x versions.
 
 
+## v1.0.1
+* Remove __final__ from classes in anticipation of moving to "WellKnown" types in `gdbots/pbj` library.
+  * BigNumber
+  * GeoPoint
+  * Microtime
+  * Identifiers\*
+
+
 ## v1.0.0
 __BREAKING CHANGES__
 

--- a/src/Common/BigNumber.php
+++ b/src/Common/BigNumber.php
@@ -2,7 +2,7 @@
 
 namespace Gdbots\Common;
 
-final class BigNumber extends \Moontoast\Math\BigNumber implements \JsonSerializable
+class BigNumber extends \Moontoast\Math\BigNumber implements \JsonSerializable
 {
     /**
      * @return string

--- a/src/Common/GeoPoint.php
+++ b/src/Common/GeoPoint.php
@@ -6,7 +6,7 @@ namespace Gdbots\Common;
  * Represents a GeoJson Point value.
  * @link http://geojson.org/geojson-spec.html#point
  */
-final class GeoPoint implements FromArray, ToArray, \JsonSerializable
+class GeoPoint implements FromArray, ToArray, \JsonSerializable
 {
     /** @var float */
     private $latitude;

--- a/src/Common/Microtime.php
+++ b/src/Common/Microtime.php
@@ -4,10 +4,14 @@ namespace Gdbots\Common;
 
 /**
  * Value object for microtime with methods to convert to and from integers.
+ * Note that this is a unix timestamp __WITH__ microseconds but stored
+ * as an integer NOT a float.
+ *
+ * 10 digits (unix timestamp) concatenated with 6 microsecond digits.
  *
  * @link http://php.net/manual/en/function.microtime.php
  */
-final class Microtime implements \JsonSerializable
+class Microtime implements \JsonSerializable
 {
     /**
      * The microtime is stored as a 16 digit integer.
@@ -107,6 +111,23 @@ final class Microtime implements \JsonSerializable
         $m->int = $int;
         $m->sec = (int) substr($int, 0, 10);
         $m->usec = (int) substr($int, -6);
+        return $m;
+    }
+
+    /**
+     * Creates a new microtime from a \DateTime object using
+     * it's timestamp and microseconds.
+     *
+     * @param \DateTime $date
+     * @return self
+     */
+    public static function fromDateTime(\DateTime $date)
+    {
+        $str = $date->format('U') . str_pad($date->format('u'), 6, '0');
+        $m = new self();
+        $m->int = (int) $str;
+        $m->sec = (int) substr($str, 0, 10);
+        $m->usec = (int) substr($str, -6);
         return $m;
     }
 

--- a/src/Identifiers/DatedSlugIdentifier.php
+++ b/src/Identifiers/DatedSlugIdentifier.php
@@ -8,7 +8,7 @@ use Gdbots\Common\Util\StringUtils;
 abstract class DatedSlugIdentifier implements Identifier, \JsonSerializable
 {
     /** @var string */
-    private $slug;
+    protected $slug;
 
     /**
      * @param string $slug
@@ -53,7 +53,7 @@ abstract class DatedSlugIdentifier implements Identifier, \JsonSerializable
      * {@inheritdoc}
      * @return static
      */
-    final public static function fromString($string)
+    public static function fromString($string)
     {
         return new static($string);
     }
@@ -61,7 +61,7 @@ abstract class DatedSlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function toString()
+    public function toString()
     {
         return $this->slug;
     }
@@ -69,7 +69,7 @@ abstract class DatedSlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function __toString()
+    public function __toString()
     {
         return $this->toString();
     }
@@ -77,7 +77,7 @@ abstract class DatedSlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function jsonSerialize()
+    public function jsonSerialize()
     {
         return $this->toString();
     }
@@ -85,7 +85,7 @@ abstract class DatedSlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function equals(Identifier $other)
+    public function equals(Identifier $other)
     {
         return $this == $other;
     }

--- a/src/Identifiers/SlugIdentifier.php
+++ b/src/Identifiers/SlugIdentifier.php
@@ -8,7 +8,7 @@ use Gdbots\Common\Util\StringUtils;
 abstract class SlugIdentifier implements Identifier, \JsonSerializable
 {
     /** @var string */
-    private $slug;
+    protected $slug;
 
     /**
      * @param string $slug
@@ -44,7 +44,7 @@ abstract class SlugIdentifier implements Identifier, \JsonSerializable
      * {@inheritdoc}
      * @return static
      */
-    final public static function fromString($string)
+    public static function fromString($string)
     {
         return new static($string);
     }
@@ -52,7 +52,7 @@ abstract class SlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function toString()
+    public function toString()
     {
         return $this->slug;
     }
@@ -60,7 +60,7 @@ abstract class SlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function __toString()
+    public function __toString()
     {
         return $this->toString();
     }
@@ -68,7 +68,7 @@ abstract class SlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function jsonSerialize()
+    public function jsonSerialize()
     {
         return $this->toString();
     }
@@ -76,7 +76,7 @@ abstract class SlugIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function equals(Identifier $other)
+    public function equals(Identifier $other)
     {
         return $this == $other;
     }

--- a/src/Identifiers/StringIdentifier.php
+++ b/src/Identifiers/StringIdentifier.php
@@ -7,7 +7,7 @@ use Gdbots\Common\Util\StringUtils;
 abstract class StringIdentifier implements Identifier, \JsonSerializable
 {
     /** @var string */
-    private $string;
+    protected $string;
 
     /**
      * @param string $string
@@ -32,7 +32,7 @@ abstract class StringIdentifier implements Identifier, \JsonSerializable
      * {@inheritdoc}
      * @return static
      */
-    final public static function fromString($string)
+    public static function fromString($string)
     {
         return new static($string);
     }
@@ -40,7 +40,7 @@ abstract class StringIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function toString()
+    public function toString()
     {
         return $this->string;
     }
@@ -48,7 +48,7 @@ abstract class StringIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function __toString()
+    public function __toString()
     {
         return $this->toString();
     }
@@ -56,7 +56,7 @@ abstract class StringIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function jsonSerialize()
+    public function jsonSerialize()
     {
         return $this->toString();
     }
@@ -64,7 +64,7 @@ abstract class StringIdentifier implements Identifier, \JsonSerializable
     /**
      * {@inheritdoc}
      */
-    final public function equals(Identifier $other)
+    public function equals(Identifier $other)
     {
         return $this == $other;
     }

--- a/src/Identifiers/UuidIdentifier.php
+++ b/src/Identifiers/UuidIdentifier.php
@@ -8,7 +8,7 @@ use Ramsey\Uuid\UuidInterface;
 class UuidIdentifier implements Identifier, GeneratesIdentifier, \JsonSerializable
 {
     /** @var UuidInterface */
-    private $uuid;
+    protected $uuid;
 
     /**
      * @param UuidInterface $uuid
@@ -31,7 +31,7 @@ class UuidIdentifier implements Identifier, GeneratesIdentifier, \JsonSerializab
      * {@inheritdoc}
      * @return static
      */
-    final public static function fromString($string)
+    public static function fromString($string)
     {
         return new static(Uuid::fromString($string));
     }
@@ -39,7 +39,7 @@ class UuidIdentifier implements Identifier, GeneratesIdentifier, \JsonSerializab
     /**
      * {@inheritdoc}
      */
-    final public function toString()
+    public function toString()
     {
         return $this->uuid->toString();
     }
@@ -47,7 +47,7 @@ class UuidIdentifier implements Identifier, GeneratesIdentifier, \JsonSerializab
     /**
      * {@inheritdoc}
      */
-    final public function __toString()
+    public function __toString()
     {
         return $this->toString();
     }
@@ -55,7 +55,7 @@ class UuidIdentifier implements Identifier, GeneratesIdentifier, \JsonSerializab
     /**
      * {@inheritdoc}
      */
-    final public function jsonSerialize()
+    public function jsonSerialize()
     {
         return $this->toString();
     }
@@ -63,7 +63,7 @@ class UuidIdentifier implements Identifier, GeneratesIdentifier, \JsonSerializab
     /**
      * {@inheritdoc}
      */
-    final public function equals(Identifier $other)
+    public function equals(Identifier $other)
     {
         return $this == $other;
     }

--- a/tests/Common/MicrotimeTest.php
+++ b/tests/Common/MicrotimeTest.php
@@ -78,6 +78,10 @@ class MicrotimeTest extends \PHPUnit_Framework_TestCase
         $date = \DateTime::createFromFormat('U.u', $sec . '.' . $usec);
         $m = Microtime::fromString($sec . $usec);
         $this->assertSame($date->format('Y-m-d H:i:s.u'), $m->toDateTime()->format('Y-m-d H:i:s.u'));
+        $this->assertSame(
+            Microtime::fromDateTime($date)->toDateTime()->format('Y-m-d H:i:s.u'),
+            $m->toDateTime()->format('Y-m-d H:i:s.u')
+        );
     }
 
     public function testDateTimeComparison()


### PR DESCRIPTION
These common classes for geopoint, microtime and identifiers will be moving to gdbots/pbj lib.  For now, make it possible to extend them in pbj so they can be deprecated here in this lib in next major rev.
